### PR TITLE
Media library improvements: robustness, deduplication, Android sync, and UI overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ run_web:
 	cd client && npm run dev
 
 run_api:
-	uv run twitch-spy --output-dir ./data
+	uv run twitch-spy --output-dir ./data --android-dest /sdcard/SdCardBackup/Music
 
 format:
 	cd client && npm run format

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -46,3 +46,77 @@
     --font-size: 16px;
     --transition-time: 0.3s;
 }
+
+/* ── react-h5-audio-player overrides ──────────────────────── */
+.rhap_container {
+    background: transparent !important;
+    box-shadow: none !important;
+    border: none !important;
+    padding: 0 !important;
+}
+
+.rhap_controls-section,
+.rhap_progress-section {
+    color: var(--text-primary, #e8eaf6) !important;
+}
+
+.rhap_play-pause-button,
+.rhap_main-controls-button,
+.rhap_skip-button,
+.rhap_rewind-button,
+.rhap_forward-button,
+.rhap_volume-button {
+    color: var(--text-primary, #e8eaf6) !important;
+}
+
+.rhap_progress-bar {
+    background: rgba(255, 255, 255, 0.1) !important;
+}
+
+.rhap_progress-filled {
+    background: linear-gradient(90deg, #7c5cff, #a08aff) !important;
+}
+
+.rhap_progress-indicator {
+    background: #a08aff !important;
+    box-shadow: 0 0 6px rgba(124, 92, 255, 0.7) !important;
+}
+
+.rhap_download-progress {
+    background: rgba(255, 255, 255, 0.08) !important;
+}
+
+.rhap_volume-bar {
+    background: rgba(255, 255, 255, 0.12) !important;
+}
+
+.rhap_volume-filled {
+    background: #7c5cff !important;
+}
+
+.rhap_volume-indicator {
+    background: #a08aff !important;
+    border: none !important;
+    box-shadow: 0 0 4px rgba(124, 92, 255, 0.6) !important;
+}
+
+.rhap_time {
+    color: rgba(196, 204, 226, 0.55) !important;
+    font-size: 0.75rem !important;
+}
+
+.rhap_additional-controls {
+    display: none !important;
+}
+
+.rhap_volume-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+@media (max-width: 900px) {
+    .rhap_volume-container {
+        display: none;
+    }
+}

--- a/client/src/App.module.css
+++ b/client/src/App.module.css
@@ -97,31 +97,6 @@
   gap: 8px;
 }
 
-.comingSoon {
-  font-size: 0.62rem;
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  color: rgba(196, 204, 226, 0.45);
-  letter-spacing: 0.04em;
-  text-transform: lowercase;
-}
-
-.syncButton {
-  width: 100%;
-  padding: 11px 16px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px dashed rgba(255, 255, 255, 0.07);
-  color: rgba(196, 204, 226, 0.25);
-  font-size: 0.88rem;
-  font-family: inherit;
-  cursor: not-allowed;
-  text-align: center;
-  transition: none;
-  box-shadow: none;
-  transform: none;
-}
 
 /* ─── Main content ──────────────────────────────────────── */
 .mainContent {

--- a/client/src/App.module.css
+++ b/client/src/App.module.css
@@ -117,51 +117,7 @@
   z-index: 20;
 }
 
-/* ─── RHAP audio player overrides ──────────────────────── */
-:global(.rhap_container) {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  padding: 0;
-  color: var(--text-primary);
-}
-
-:global(.rhap_progress-filled) {
-  background-image: linear-gradient(90deg, var(--accent) 0%, var(--accent-soft) 100%);
-  box-shadow: 0 0 10px rgba(124, 92, 255, 0.35);
-}
-
-:global(.rhap_download-progress) {
-  background: rgba(255, 255, 255, 0.14);
-}
-
-:global(.rhap_play-pause-button),
-:global(.rhap_main-controls-button) {
-  color: var(--text-primary);
-}
-
-:global(.rhap_volume-bar),
-:global(.rhap_volume-bar-area) {
-  background: rgba(255, 255, 255, 0.12);
-}
-
-:global(.rhap_volume-indicator) {
-  background: var(--accent);
-}
-
-:global(.rhap_time) {
-  color: var(--text-tertiary);
-}
-
-:global(.rhap_additional-controls) {
-  display: none;
-}
-
-:global(.rhap_volume-container) {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
+/* ─── RHAP volume layout ────────────────────────────────── */
 
 /* ─── Responsive ────────────────────────────────────────── */
 @media (max-width: 900px) {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import MusicPlayer from "./components/AudioPlayer.tsx";
 import type {Atom} from "./backend/models.ts";
 import JobOverview from "./components/JobOverview.tsx";
 import JobList from "./components/JobList.tsx";
+import SyncPanel from "./components/SyncPanel.tsx";
 import {BACKEND_URL} from "./backend/backend.ts";
 import {io} from "socket.io-client";
 
@@ -52,13 +53,8 @@ function App() {
                 </div>
 
                 <div className={styles.sidebarSection}>
-                    <span className={styles.sectionLabel}>
-                        Sync to device
-                        <span className={styles.comingSoon}>soon</span>
-                    </span>
-                    <button className={styles.syncButton} disabled>
-                        Connect a device
-                    </button>
+                    <span className={styles.sectionLabel}>Sync to device</span>
+                    <SyncPanel socket={socket} />
                 </div>
             </aside>
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
 
                 <div className={styles.sidebarSection}>
                     <span className={styles.sectionLabel}>Download</span>
-                    <URLInput />
+                    <URLInput socket={socket} />
                 </div>
 
                 <div className={styles.sidebarSection}>

--- a/client/src/backend/models.ts
+++ b/client/src/backend/models.ts
@@ -41,3 +41,34 @@ export interface JobStatistics {
 }
 
 export type JobStatKey = keyof JobStatistics;
+
+// ── Android sync ──────────────────────────────────────────────────────────────
+
+export interface FileTransferOp {
+  local_path: string;
+  remote_path: string;
+  size_bytes: number;
+  filename: string;
+}
+
+export interface SyncPlan {
+  dirs_to_create: string[];
+  files_to_transfer: FileTransferOp[];
+  skipped_count: number;
+  total_transfer_bytes: number;
+}
+
+export interface SyncProgress {
+  current: number;
+  total: number;
+  filename: string;
+  remote_path: string;
+  status: "ok" | "failed";
+}
+
+export interface SyncResult {
+  uploaded: number;
+  skipped: number;
+  failed: number;
+  errors: string[];
+}

--- a/client/src/components/AudioPlayer.module.css
+++ b/client/src/components/AudioPlayer.module.css
@@ -9,6 +9,35 @@
   flex: 0 0 clamp(180px, 22vw, 280px);
 }
 
+.centerPane {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.playButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 44px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(124, 92, 255, 0.18);
+  color: #e8eaf6;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.playButton:hover {
+  background: rgba(124, 92, 255, 0.35);
+}
+
+.playButton:active {
+  transform: scale(0.95);
+}
+
 .rightPane {
   flex: 1 1 auto;
   display: flex;
@@ -23,6 +52,10 @@
   .leftPane {
     flex: 0 0 clamp(140px, 30vw, 200px);
   }
+
+  .playButton {
+    width: 64px;
+  }
 }
 
 @media (max-width: 600px) {
@@ -32,5 +65,9 @@
 
   .leftPane {
     flex: 0 0 120px;
+  }
+
+  .playButton {
+    width: 52px;
   }
 }

--- a/client/src/components/AudioPlayer.tsx
+++ b/client/src/components/AudioPlayer.tsx
@@ -1,10 +1,22 @@
-import React, {useEffect, useState} from "react";
-import AudioPlayer from "react-h5-audio-player";
+import React, {useEffect, useRef, useState} from "react";
+import AudioPlayer, {RHAP_UI} from "react-h5-audio-player";
 import "react-h5-audio-player/lib/styles.css";
 import {BACKEND_URL} from "../backend/backend.ts";
 import CurrentTrackDisplay from "./CurrentTrackDisplay.tsx";
 import type {Atom} from "../backend/models.ts";
 import styles from "./AudioPlayer.module.css";
+
+const PlayIcon = () => (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="26" height="26">
+        <path d="M8 5v14l11-7z"/>
+    </svg>
+);
+
+const PauseIcon = () => (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="26" height="26">
+        <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/>
+    </svg>
+);
 
 interface AudioPlayerProps {
     entry: Atom | undefined;
@@ -13,6 +25,8 @@ interface AudioPlayerProps {
 const MusicPlayer: React.FC<AudioPlayerProps> = ({entry}) => {
     const [currentTrack, setCurrentTrack] = useState<string | undefined>();
     const [trackColor, setTrackColor] = useState<string>("#4a4a4a");
+    const [isPlaying, setIsPlaying] = useState(false);
+    const playerRef = useRef<any>(null);
 
     useEffect(() => {
         if (entry) {
@@ -73,7 +87,16 @@ const MusicPlayer: React.FC<AudioPlayerProps> = ({entry}) => {
 
     const handleNextTrack = () => {
         console.log("Next track functionality can be implemented here.");
-        // Implement logic to fetch or select the next track title and update the state
+    };
+
+    const togglePlay = () => {
+        const audio = playerRef.current?.audio?.current;
+        if (!audio) return;
+        if (isPlaying) {
+            audio.pause();
+        } else {
+            audio.play();
+        }
     };
 
     const getRandomColor = () => {
@@ -88,13 +111,34 @@ const MusicPlayer: React.FC<AudioPlayerProps> = ({entry}) => {
             <div className={styles.leftPane}>
                 <CurrentTrackDisplay title={entry?.content_name} color={trackColor}/>
             </div>
+            <div className={styles.centerPane}>
+                <button
+                    className={styles.playButton}
+                    onClick={togglePlay}
+                    aria-label={isPlaying ? "Pause" : "Play"}
+                >
+                    {isPlaying ? <PauseIcon/> : <PlayIcon/>}
+                </button>
+            </div>
             <div className={styles.rightPane}>
                 <AudioPlayer
+                    ref={playerRef}
                     autoPlay
                     autoPlayAfterSrcChange
                     src={currentTrack}
                     showJumpControls={false}
-                    onEnded={handleNextTrack}
+                    customControlsSection={[RHAP_UI.VOLUME_CONTROLS]}
+                    customProgressBarSection={[
+                        RHAP_UI.CURRENT_TIME,
+                        RHAP_UI.PROGRESS_BAR,
+                        RHAP_UI.CURRENT_LEFT_TIME,
+                    ]}
+                    onPlay={() => setIsPlaying(true)}
+                    onPause={() => setIsPlaying(false)}
+                    onEnded={() => {
+                        setIsPlaying(false);
+                        handleNextTrack();
+                    }}
                 />
             </div>
         </div>

--- a/client/src/components/SyncPanel.module.css
+++ b/client/src/components/SyncPanel.module.css
@@ -1,0 +1,303 @@
+.block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.statusText {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.warn {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--warning);
+}
+
+.successText {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #4dffb0;
+  font-weight: 600;
+}
+
+/* ── Dot ────────────────────────────────────────────────── */
+.dotGreen {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #4dffb0;
+  box-shadow: 0 0 6px #4dffb0;
+  flex-shrink: 0;
+}
+
+/* ── Spinner ────────────────────────────────────────────── */
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(124, 92, 255, 0.25);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Plan summary ───────────────────────────────────────── */
+.planSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.planRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.planLabel {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.planValue {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.planValueGreen {
+  font-size: 0.75rem;
+  color: #4dffb0;
+  font-weight: 600;
+}
+
+.planValueRed {
+  font-size: 0.75rem;
+  color: var(--warning);
+  font-weight: 600;
+}
+
+/* ── Progress bar ───────────────────────────────────────── */
+.progressTrack {
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), #a08aff);
+  transition: width 200ms ease;
+}
+
+.currentFile {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Details toggle ─────────────────────────────────────── */
+.detailsToggle {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  text-align: left;
+  box-shadow: none;
+  transform: none;
+  letter-spacing: 0.03em;
+}
+
+.detailsToggle:hover {
+  color: var(--text-secondary);
+  transform: none;
+  box-shadow: none;
+}
+
+/* ── Details panel ──────────────────────────────────────── */
+.detailsPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(124, 92, 255, 0.2) transparent;
+}
+
+.detailSection {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.detailHeading {
+  margin: 0;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.detailHeadingMeta {
+  font-size: 0.68rem;
+  text-transform: none;
+  letter-spacing: 0;
+  color: rgba(196, 204, 226, 0.45);
+  font-weight: 400;
+}
+
+.detailItemMuted {
+  opacity: 0.5;
+}
+
+.fileGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-top: 6px;
+}
+
+.fileGroupHeader {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.fileGroup .detailItem {
+  padding-left: 14px;
+}
+
+.detailList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.detailItem {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  min-width: 0;
+}
+
+.detailIcon {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+}
+
+.detailName {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.detailSize {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-size: 0.7rem;
+}
+
+/* ── Buttons ────────────────────────────────────────────── */
+.btnRow {
+  display: flex;
+  gap: 8px;
+}
+
+.primaryBtn {
+  width: 100%;
+  padding: 9px 14px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-soft) 100%);
+  color: var(--text-on-accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-family: inherit;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 8px 24px -12px rgba(124, 92, 255, 0.7);
+  transition: box-shadow var(--transition-medium) ease, opacity var(--transition-medium) ease;
+}
+
+.primaryBtn:hover:not(:disabled) {
+  box-shadow: 0 12px 28px -12px rgba(124, 92, 255, 0.85);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.ghostBtn {
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background var(--transition-medium) ease;
+}
+
+.ghostBtn:hover {
+  background: rgba(255, 255, 255, 0.09);
+  transform: none;
+  box-shadow: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+
+  .progressFill,
+  .primaryBtn,
+  .ghostBtn {
+    transition: none;
+  }
+}

--- a/client/src/components/SyncPanel.tsx
+++ b/client/src/components/SyncPanel.tsx
@@ -1,0 +1,329 @@
+import React, {useEffect, useState} from "react";
+import {Socket} from "socket.io-client";
+import {BACKEND_URL} from "../backend/backend.ts";
+import type {SyncPlan, SyncProgress, SyncResult} from "../backend/models.ts";
+import styles from "./SyncPanel.module.css";
+
+interface SyncPanelProps {
+    socket: Socket;
+}
+
+type Phase =
+    | {tag: "idle"}
+    | {tag: "checking"}
+    | {tag: "no_device"}
+    | {tag: "device_ready"; devices: string[]}
+    | {tag: "planning"}
+    | {tag: "plan_ready"; plan: SyncPlan}
+    | {tag: "syncing"; plan: SyncPlan; progress: SyncProgress | null}
+    | {tag: "complete"; result: SyncResult}
+    | {tag: "error"; message: string};
+
+function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1_048_576) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / 1_048_576).toFixed(1)} MB`;
+}
+
+// Strip a common path prefix for display (e.g. "/sdcard/SdCardBackup/Music/Foo" → "Foo")
+function stripPrefix(path: string, prefix: string): string {
+    const p = prefix.endsWith("/") ? prefix : prefix + "/";
+    return path.startsWith(p) ? path.slice(p.length) : path;
+}
+
+const SyncPanel: React.FC<SyncPanelProps> = ({socket}) => {
+    const [phase, setPhase] = useState<Phase>({tag: "idle"});
+    const [showDetails, setShowDetails] = useState(true);
+
+    // Listen for Socket.IO events emitted by the backend during execute.
+    useEffect(() => {
+        const onProgress = (data: SyncProgress) => {
+            setPhase((prev) => {
+                if (prev.tag !== "syncing") return prev;
+                return {...prev, progress: data};
+            });
+        };
+
+        const onComplete = (data: SyncResult) => {
+            setPhase({tag: "complete", result: data});
+        };
+
+        socket.on("sync_progress", onProgress);
+        socket.on("sync_complete", onComplete);
+        return () => {
+            socket.off("sync_progress", onProgress);
+            socket.off("sync_complete", onComplete);
+        };
+    }, [socket]);
+
+    // ── Actions ──────────────────────────────────────────────────────────────
+
+    const checkDevice = async () => {
+        setPhase({tag: "checking"});
+        try {
+            const res = await fetch(`${BACKEND_URL}/sync/devices`);
+            const data = await res.json();
+            if (data.connected) {
+                setPhase({tag: "device_ready", devices: data.devices});
+            } else {
+                setPhase({tag: "no_device"});
+            }
+        } catch {
+            setPhase({tag: "error", message: "Could not reach backend"});
+        }
+    };
+
+    const buildPlan = async () => {
+        setPhase({tag: "planning"});
+        try {
+            const res = await fetch(`${BACKEND_URL}/sync/plan`, {method: "POST"});
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                setPhase({tag: "error", message: data.error ?? `HTTP ${res.status}`});
+                return;
+            }
+            const plan: SyncPlan = await res.json();
+            setPhase({tag: "plan_ready", plan});
+        } catch (err) {
+            setPhase({tag: "error", message: String(err)});
+        }
+    };
+
+    const confirmSync = async (plan: SyncPlan) => {
+        setPhase({tag: "syncing", plan, progress: null});
+        try {
+            await fetch(`${BACKEND_URL}/sync/execute`, {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify(plan),
+            });
+            // Completion arrives via sync_complete socket event.
+        } catch (err) {
+            setPhase({tag: "error", message: String(err)});
+        }
+    };
+
+    const reset = () => setPhase({tag: "idle"});
+
+    // ── Render ───────────────────────────────────────────────────────────────
+
+    if (phase.tag === "idle") {
+        return (
+            <button className={styles.primaryBtn} onClick={checkDevice}>
+                Scan for device
+            </button>
+        );
+    }
+
+    if (phase.tag === "checking") {
+        return <p className={styles.statusText}><span className={styles.spinner} />Checking device…</p>;
+    }
+
+    if (phase.tag === "no_device") {
+        return (
+            <div className={styles.block}>
+                <p className={styles.warn}>No device found via adb</p>
+                <button className={styles.ghostBtn} onClick={checkDevice}>Retry</button>
+            </div>
+        );
+    }
+
+    if (phase.tag === "device_ready") {
+        return (
+            <div className={styles.block}>
+                <p className={styles.statusText}>
+                    <span className={styles.dotGreen} />
+                    {phase.devices[0]}
+                </p>
+                <button className={styles.primaryBtn} onClick={buildPlan}>
+                    Plan sync
+                </button>
+            </div>
+        );
+    }
+
+    if (phase.tag === "planning") {
+        return <p className={styles.statusText}><span className={styles.spinner} />Scanning library…</p>;
+    }
+
+    if (phase.tag === "plan_ready") {
+        const {plan} = phase;
+        const count = plan.files_to_transfer.length;
+
+        // Derive the android_dest prefix from the first remote path so we can
+        // display relative paths without knowing the config value in the client.
+        const remoteRoot = plan.files_to_transfer[0]?.remote_path
+            .split("/").slice(0, -1).join("/") ?? "";
+        const commonRoot = plan.dirs_to_create.length > 0
+            ? plan.dirs_to_create[0].split("/").slice(0, -1).join("/")
+            : remoteRoot;
+
+        return (
+            <div className={styles.block}>
+                <div className={styles.planSummary}>
+                    <div className={styles.planRow}>
+                        <span className={styles.planLabel}>Transfer</span>
+                        <span className={styles.planValue}>
+                            {count} file{count !== 1 ? "s" : ""} &middot; {formatBytes(plan.total_transfer_bytes)}
+                        </span>
+                    </div>
+                    <div className={styles.planRow}>
+                        <span className={styles.planLabel}>Already synced</span>
+                        <span className={styles.planValue}>{plan.skipped_count}</span>
+                    </div>
+                    <div className={styles.planRow}>
+                        <span className={styles.planLabel}>New dirs</span>
+                        <span className={styles.planValue}>{plan.dirs_to_create.length}</span>
+                    </div>
+                </div>
+
+                <button
+                    className={styles.detailsToggle}
+                    onClick={() => setShowDetails((v) => !v)}
+                >
+                    {showDetails ? "▲ Hide details" : "▼ Show details"}
+                </button>
+
+                {showDetails && (
+                    <div className={styles.detailsPanel}>
+                        {(() => {
+                            // Group files by remote parent directory.
+                            const groups = new Map<string, typeof plan.files_to_transfer>();
+                            for (const op of plan.files_to_transfer) {
+                                const dir = op.remote_path.split("/").slice(0, -1).join("/");
+                                if (!groups.has(dir)) groups.set(dir, []);
+                                groups.get(dir)!.push(op);
+                            }
+
+                            return (
+                                <>
+                                    {/* Section 1: all directories to create */}
+                                    {plan.dirs_to_create.length > 0 && (
+                                        <div className={styles.detailSection}>
+                                            <p className={styles.detailHeading}>
+                                                Directories to create ({plan.dirs_to_create.length})
+                                            </p>
+                                            <ul className={styles.detailList}>
+                                                {plan.dirs_to_create.map((d) => (
+                                                    <li key={d} className={styles.detailItem} title={d}>
+                                                        <span className={styles.detailIcon}>📁</span>
+                                                        <span className={styles.detailName}>{stripPrefix(d, commonRoot)}</span>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    )}
+
+                                    {/* Section 2: files grouped by their remote directory */}
+                                    {groups.size > 0 && (
+                                        <div className={styles.detailSection}>
+                                            <p className={styles.detailHeading}>
+                                                Files to transfer ({count})
+                                            </p>
+                                            {Array.from(groups.entries()).map(([dir, files]) => {
+                                                const dirBytes = files.reduce((s, f) => s + f.size_bytes, 0);
+                                                const label = stripPrefix(dir, commonRoot) || dir;
+                                                return (
+                                                    <div key={dir} className={styles.fileGroup}>
+                                                        <p className={styles.fileGroupHeader} title={dir}>
+                                                            📁 {label}
+                                                            <span className={styles.detailHeadingMeta}>
+                                                                {files.length} file{files.length !== 1 ? "s" : ""} · {formatBytes(dirBytes)}
+                                                            </span>
+                                                        </p>
+                                                        <ul className={styles.detailList}>
+                                                            {files.map((op) => (
+                                                                <li key={op.remote_path} className={styles.detailItem} title={op.remote_path}>
+                                                                    <span className={styles.detailIcon}>♪</span>
+                                                                    <span className={styles.detailName}>{op.filename}</span>
+                                                                    <span className={styles.detailSize}>{formatBytes(op.size_bytes)}</span>
+                                                                </li>
+                                                            ))}
+                                                        </ul>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    )}
+                                </>
+                            );
+                        })()}
+                    </div>
+                )}
+
+                <div className={styles.btnRow}>
+                    <button className={styles.ghostBtn} onClick={reset}>Cancel</button>
+                    <button
+                        className={styles.primaryBtn}
+                        onClick={() => confirmSync(plan)}
+                        disabled={count === 0}
+                    >
+                        {count === 0 ? "Already up to date" : "Confirm sync →"}
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    if (phase.tag === "syncing") {
+        const {plan, progress} = phase;
+        const total = plan.files_to_transfer.length;
+        const current = progress?.current ?? 0;
+        const pct = total > 0 ? Math.round((current / total) * 100) : 0;
+        return (
+            <div className={styles.block}>
+                <p className={styles.statusText}>
+                    <span className={styles.spinner} />
+                    Syncing… {current}/{total}
+                </p>
+                <div className={styles.progressTrack}>
+                    <div className={styles.progressFill} style={{width: `${pct}%`}} />
+                </div>
+                {progress && (
+                    <p className={styles.currentFile} title={progress.remote_path}>
+                        {progress.filename}
+                    </p>
+                )}
+            </div>
+        );
+    }
+
+    if (phase.tag === "complete") {
+        const {result} = phase;
+        return (
+            <div className={styles.block}>
+                <p className={styles.successText}>Sync complete</p>
+                <div className={styles.planSummary}>
+                    <div className={styles.planRow}>
+                        <span className={styles.planLabel}>Uploaded</span>
+                        <span className={styles.planValueGreen}>{result.uploaded}</span>
+                    </div>
+                    <div className={styles.planRow}>
+                        <span className={styles.planLabel}>Skipped</span>
+                        <span className={styles.planValue}>{result.skipped}</span>
+                    </div>
+                    {result.failed > 0 && (
+                        <div className={styles.planRow}>
+                            <span className={styles.planLabel}>Failed</span>
+                            <span className={styles.planValueRed}>{result.failed}</span>
+                        </div>
+                    )}
+                </div>
+                <button className={styles.ghostBtn} onClick={reset}>New sync</button>
+            </div>
+        );
+    }
+
+    if (phase.tag === "error") {
+        return (
+            <div className={styles.block}>
+                <p className={styles.warn}>{phase.message}</p>
+                <button className={styles.ghostBtn} onClick={reset}>Dismiss</button>
+            </div>
+        );
+    }
+
+    return null;
+};
+
+export default SyncPanel;

--- a/client/src/components/URLInput.module.css
+++ b/client/src/components/URLInput.module.css
@@ -86,6 +86,11 @@
   opacity: 1;
 }
 
+.planningText {
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+}
+
 .metaRow {
   display: flex;
   flex-wrap: wrap;

--- a/client/src/components/URLInput.tsx
+++ b/client/src/components/URLInput.tsx
@@ -8,8 +8,23 @@ export const URLInput = () => {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const formRef = useRef<HTMLFormElement>(null);
 
+    const unwrapIfJsonArray = (input: string): string => {
+        const trimmed = input.trim();
+        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+            try {
+                const parsed = JSON.parse(trimmed);
+                if (Array.isArray(parsed) && parsed.every((x) => typeof x === "string")) {
+                    return parsed.join("\n");
+                }
+            } catch {
+                // fall through to normal parsing
+            }
+        }
+        return input;
+    };
+
     const cleanInput = (input: string): string =>
-        input
+        unwrapIfJsonArray(input)
             .replace(/\s+/g, ",")
             .split(",")
             .map((url) => url.trim())
@@ -24,7 +39,7 @@ export const URLInput = () => {
     };
 
     const isInputValid = (input: string): boolean => {
-        const urlList = input.replace(/\s+/g, ",").split(",");
+        const urlList = unwrapIfJsonArray(input).replace(/\s+/g, ",").split(",");
         if (urlList.some((url) => url.trim() === "")) {
             return false;
         }

--- a/client/src/components/URLInput.tsx
+++ b/client/src/components/URLInput.tsx
@@ -1,12 +1,26 @@
-import React, {useRef, useState} from "react";
+import React, {useEffect, useRef, useState} from "react";
+import {Socket} from "socket.io-client";
 import {TextInputStats} from "./util/TextInputStats.tsx";
 import {apiRequest} from "../backend/backend.ts";
 import styles from "./URLInput.module.css";
 
-export const URLInput = () => {
+interface URLInputProps {
+    socket: Socket;
+}
+
+export const URLInput = ({socket}: URLInputProps) => {
     const [userInput, setUserInput] = useState("");
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [planning, setPlanning] = useState<{current: number; total: number} | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
+
+    useEffect(() => {
+        const onPlanning = (data: {current: number; total: number}) => {
+            setPlanning(data.total > 0 ? data : null);
+        };
+        socket.on("url_planning", onPlanning);
+        return () => { socket.off("url_planning", onPlanning); };
+    }, [socket]);
 
     const unwrapIfJsonArray = (input: string): string => {
         const trimmed = input.trim();
@@ -74,6 +88,7 @@ export const URLInput = () => {
             console.error("An error occurred:", error);
         } finally {
             setIsSubmitting(false);
+            setPlanning(null);
         }
     };
 
@@ -91,7 +106,13 @@ export const URLInput = () => {
                 <span className={styles.inputGlow} aria-hidden="true" />
             </label>
             <div className={styles.metaRow}>
-                <TextInputStats urlCount={validUrlCount} inputValidity={rawInputValid} />
+                {planning ? (
+                    <span className={styles.planningText}>
+                        Planning {planning.current} / {planning.total}…
+                    </span>
+                ) : (
+                    <TextInputStats urlCount={validUrlCount} inputValidity={rawInputValid} />
+                )}
                 <div className={styles.buttonGroup}>
                     <button
                         type="button"

--- a/client/src/components/URLInput.tsx
+++ b/client/src/components/URLInput.tsx
@@ -63,7 +63,7 @@ export const URLInput = () => {
         try {
             setIsSubmitting(true);
             const response = await apiRequest("form_submit.POST", {
-                urls: userInput,
+                urls: cleanedInput,
             });
             if (response.success) {
                 setUserInput("");

--- a/src/twitch_spy/android_sync/adb_sync.py
+++ b/src/twitch_spy/android_sync/adb_sync.py
@@ -1,0 +1,436 @@
+r"""
+Android one-way library sync via adb.exe (WSL-compatible).
+
+WSL path conversion
+-------------------
+`adb.exe push` is a Windows binary, so it needs Windows-style paths.
+We convert Linux paths with `wslpath -w`:
+
+    $ wslpath -w /home/user/music/track.mp3
+    \\wsl.localhost\Ubuntu\home\user\music\track.mp3
+
+Remote path quoting
+-------------------
+`adb shell <cmd>` passes <cmd> to /bin/sh on the device.
+We use `shlex.quote()` on every remote path argument, which produces
+POSIX single-quoted strings:
+
+    shlex.quote('/sdcard/My Music/track.mp3')
+    → "'/sdcard/My Music/track.mp3'"
+
+This safely handles spaces, parentheses, and most unicode in filenames.
+
+Example usage
+-------------
+    syncer = AndroidLibrarySync(
+        adb_exe="adb.exe",
+        android_dest="/sdcard/SdCardBackup/Music",
+    )
+
+    if not syncer.device_connected():
+        raise RuntimeError("No device found — run: adb.exe devices")
+
+    plan = syncer.plan_sync("/home/user/data/stream_downloads/audio_library")
+    print(f"{len(plan.files_to_transfer)} files to transfer, {plan.skipped_count} already synced")
+
+    result = syncer.execute_plan(plan, progress_callback=lambda i, n, op, s: print(f"[{i}/{n}] {s} {op.filename}"))
+    print(result)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ── Data structures ────────────────────────────────────────────────────────────
+
+@dataclass
+class FileTransferOp:
+    local_path: str    # Absolute Linux path (WSL)
+    remote_path: str   # Absolute Android path
+    size_bytes: int
+    filename: str      # Basename, for display
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class SyncPlan:
+    dirs_to_create: list[str]                # Remote dirs that must exist before push
+    files_to_transfer: list[FileTransferOp]  # Ordered transfer operations
+    skipped_count: int                       # Files already present on device
+    total_transfer_bytes: int
+
+    def to_dict(self) -> dict:
+        return {
+            "dirs_to_create": self.dirs_to_create,
+            "files_to_transfer": [op.to_dict() for op in self.files_to_transfer],
+            "skipped_count": self.skipped_count,
+            "total_transfer_bytes": self.total_transfer_bytes,
+        }
+
+
+@dataclass
+class SyncResult:
+    uploaded: int = 0
+    skipped: int = 0
+    failed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ── Core class ─────────────────────────────────────────────────────────────────
+
+class AndroidLibrarySync:
+    """
+    One-way sync from a local library directory to an Android device via adb.exe.
+
+    Designed for WSL: local paths are converted to Windows paths with `wslpath -w`
+    before being passed to `adb.exe push`.
+
+    v1 behaviour:
+    - Copy-only: never deletes or overwrites remote files.
+    - Files that already exist at the exact remote path are skipped.
+    - Directory structure relative to `local_dir` is preserved under `android_dest`.
+    """
+
+    def __init__(
+        self,
+        adb_exe: str = "adb.exe",
+        android_dest: str = "/sdcard/SdCardBackup/Music",
+    ) -> None:
+        self.adb_exe = adb_exe
+        self.android_dest = android_dest.rstrip("/")
+
+    # ── Low-level subprocess helpers ──────────────────────────────────────────
+
+    def _run(self, args: list[str], check: bool = False) -> subprocess.CompletedProcess:
+        """Run a subprocess, always capturing output. Never raises by default."""
+        logger.debug("run: %s", " ".join(args))
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=check,
+        )
+
+    def _remote_shell(self, command: str) -> subprocess.CompletedProcess:
+        """
+        Run a shell command on the Android device.
+
+        `command` is passed as a single string to `adb shell`, which hands it
+        to /bin/sh on the device.  Always use shlex.quote() on any path that
+        appears inside `command` so spaces and special characters are safe.
+
+        Example:
+            self._remote_shell(f"mkdir -p {shlex.quote(remote_dir)}")
+        """
+        return self._run([self.adb_exe, "shell", command])
+
+    def _wsl_to_windows(self, linux_path: str) -> str:
+        r"""
+        Convert an absolute WSL Linux path to a Windows UNC path using wslpath.
+
+        Example:
+            /home/user/music/track.mp3
+            → \\wsl.localhost\Ubuntu\home\user\music\track.mp3
+
+        Required because adb.exe is a Windows binary and does not understand
+        Linux paths directly.
+        """
+        result = self._run(["wslpath", "-w", linux_path], check=True)
+        return result.stdout.strip()
+
+    # ── Device ────────────────────────────────────────────────────────────────
+
+    def list_devices(self) -> list[str]:
+        """Return serial numbers of all connected (online) devices."""
+        result = self._run([self.adb_exe, "devices"])
+        devices = []
+        for line in result.stdout.splitlines()[1:]:  # skip header
+            line = line.strip()
+            if "\t" in line:
+                serial, state = line.split("\t", 1)
+                if state.strip() == "device":
+                    devices.append(serial.strip())
+        return devices
+
+    def device_connected(self) -> bool:
+        """Return True if at least one device is online."""
+        return len(self.list_devices()) > 0
+
+    # ── Remote filesystem ─────────────────────────────────────────────────────
+
+    def ensure_remote_dir(self, remote_dir: str) -> None:
+        """Create `remote_dir` (and all parents) on the device if not present."""
+        cmd = f"mkdir -p {shlex.quote(remote_dir)}"
+        result = self._remote_shell(cmd)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"mkdir -p failed for {remote_dir!r}: {result.stderr.strip()}"
+            )
+        logger.debug("remote dir ready: %s", remote_dir)
+
+    def remote_file_exists(self, remote_path: str) -> bool:
+        """Return True if `remote_path` exists on the device."""
+        cmd = f"test -e {shlex.quote(remote_path)} && echo 1 || echo 0"
+        result = self._remote_shell(cmd)
+        return result.stdout.strip() == "1"
+
+    def list_remote_files(self, remote_dir: str) -> set[str]:
+        """
+        Return a set of all file paths currently under `remote_dir` on the device.
+
+        Uses a single `adb shell find` call — much faster than checking each
+        file individually when the library is large.
+        """
+        cmd = f"find {shlex.quote(remote_dir)} -type f 2>/dev/null"
+        result = self._remote_shell(cmd)
+        if result.returncode != 0 and not result.stdout.strip():
+            logger.warning(
+                "find returned non-zero for %s (directory may be empty or missing)",
+                remote_dir,
+            )
+            return set()
+        return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+    # ── Push ──────────────────────────────────────────────────────────────────
+
+    def push_file(self, local_path: str, remote_path: str) -> bool:
+        """
+        Push a single file to the device.
+
+        Converts the local Linux path to a Windows path via `wslpath -w` before
+        calling `adb.exe push`.  Returns True on success, False on any error.
+        Errors are logged but not raised, so callers can continue on failure.
+        """
+        try:
+            win_path = self._wsl_to_windows(local_path)
+        except subprocess.CalledProcessError as exc:
+            logger.error("wslpath failed for %r: %s", local_path, exc)
+            return False
+
+        # remote_path is passed as a direct argument — no shell involved here,
+        # so no additional quoting is needed at this layer.
+        result = self._run([self.adb_exe, "push", win_path, remote_path])
+        if result.returncode != 0:
+            logger.error(
+                "push failed [%s → %s]: %s",
+                local_path,
+                remote_path,
+                result.stderr.strip(),
+            )
+            return False
+
+        logger.info("pushed: %s → %s", local_path, remote_path)
+        return True
+
+    # ── Sync ──────────────────────────────────────────────────────────────────
+
+    def plan_sync(self, local_dir: str) -> SyncPlan:
+        """
+        Walk `local_dir` and compute which files need to be transferred.
+
+        Does NOT write anything to the device.  Only reads the remote file list
+        (one bulk `adb shell find` call) and the local filesystem.
+
+        The relative directory structure under `local_dir` is preserved under
+        `android_dest`.  Example:
+
+            local_dir  = /data/audio_library
+            file       = /data/audio_library/Playlist A/track.mp3
+            remote     = /sdcard/SdCardBackup/Music/Playlist A/track.mp3
+        """
+        local_root = Path(local_dir).resolve()
+        if not local_root.is_dir():
+            raise ValueError(f"local_dir does not exist or is not a directory: {local_dir}")
+
+        logger.info("planning sync: %s → %s", local_root, self.android_dest)
+
+        # One bulk query avoids O(n) adb round-trips.
+        existing_remote = self.list_remote_files(self.android_dest)
+        logger.info("device has %d existing files under %s", len(existing_remote), self.android_dest)
+
+        dirs_to_create: list[str] = []
+        files_to_transfer: list[FileTransferOp] = []
+        skipped = 0
+        seen_dirs: set[str] = set()
+
+        for local_file in sorted(local_root.rglob("*")):
+            if not local_file.is_file():
+                continue
+
+            rel = local_file.relative_to(local_root)
+            # Build remote path by joining parts individually so that the
+            # separator is always "/" regardless of the local OS.
+            remote_path = self.android_dest + "/" + "/".join(rel.parts)
+            remote_dir = remote_path.rsplit("/", 1)[0]
+
+            if remote_path in existing_remote:
+                skipped += 1
+                logger.debug("skip (exists): %s", remote_path)
+                continue
+
+            # Track unique remote directories that need creating.
+            if remote_dir != self.android_dest and remote_dir not in seen_dirs:
+                dirs_to_create.append(remote_dir)
+                seen_dirs.add(remote_dir)
+
+            files_to_transfer.append(
+                FileTransferOp(
+                    local_path=str(local_file),
+                    remote_path=remote_path,
+                    size_bytes=local_file.stat().st_size,
+                    filename=local_file.name,
+                )
+            )
+
+        total_bytes = sum(op.size_bytes for op in files_to_transfer)
+        logger.info(
+            "plan ready — transfer: %d files (%.1f MB), skip: %d, new dirs: %d",
+            len(files_to_transfer),
+            total_bytes / 1_048_576,
+            skipped,
+            len(dirs_to_create),
+        )
+        return SyncPlan(
+            dirs_to_create=dirs_to_create,
+            files_to_transfer=files_to_transfer,
+            skipped_count=skipped,
+            total_transfer_bytes=total_bytes,
+        )
+
+    def execute_plan(
+        self,
+        plan: SyncPlan,
+        progress_callback=None,
+    ) -> SyncResult:
+        """
+        Execute a previously computed SyncPlan.
+
+        `progress_callback`, if provided, is called after each file transfer:
+            callback(current: int, total: int, op: FileTransferOp, status: str)
+        where `status` is "ok" or "failed".
+
+        Errors on individual files are logged and counted but do not abort
+        the rest of the sync.
+        """
+        result = SyncResult(skipped=plan.skipped_count)
+        total = len(plan.files_to_transfer)
+
+        # Step 1: ensure all required remote directories exist.
+        for remote_dir in plan.dirs_to_create:
+            try:
+                self.ensure_remote_dir(remote_dir)
+            except RuntimeError as exc:
+                # Log but continue — the push itself will fail if the dir is
+                # truly missing, and that failure is captured per-file below.
+                logger.warning("dir creation warning: %s", exc)
+
+        # Step 2: push files one by one.
+        for i, op in enumerate(plan.files_to_transfer, start=1):
+            ok = self.push_file(op.local_path, op.remote_path)
+            if ok:
+                result.uploaded += 1
+                status = "ok"
+            else:
+                result.failed += 1
+                result.errors.append(op.remote_path)
+                status = "failed"
+
+            if progress_callback:
+                try:
+                    progress_callback(i, total, op, status)
+                except Exception as exc:
+                    logger.warning("progress_callback raised: %s", exc)
+
+        logger.info(
+            "sync complete — uploaded: %d  skipped: %d  failed: %d",
+            result.uploaded,
+            result.skipped,
+            result.failed,
+        )
+        return result
+
+
+# ── CLI entrypoint for manual testing ─────────────────────────────────────────
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Android one-way sync (dry-run by default)"
+    )
+    parser.add_argument("local_dir", help="Local directory to sync")
+    parser.add_argument(
+        "--android-dest",
+        default="/sdcard/SdCardBackup/Music",
+        help="Remote root on the Android device",
+    )
+    parser.add_argument(
+        "--adb-exe",
+        default="adb.exe",
+        help="adb executable name (default: adb.exe for WSL)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually transfer files (default is dry-run / plan only)",
+    )
+    args = parser.parse_args()
+
+    syncer = AndroidLibrarySync(adb_exe=args.adb_exe, android_dest=args.android_dest)
+
+    print("Checking for connected devices...")
+    devices = syncer.list_devices()
+    if not devices:
+        print("No device found.  Make sure USB debugging is on and run: adb.exe devices")
+        sys.exit(1)
+    print(f"Device(s): {', '.join(devices)}")
+
+    print(f"\nBuilding sync plan: {args.local_dir} → {args.android_dest}")
+    plan = syncer.plan_sync(args.local_dir)
+
+    print(f"\n=== Sync Plan ===")
+    print(f"  Files to transfer : {len(plan.files_to_transfer)}  ({plan.total_transfer_bytes / 1_048_576:.1f} MB)")
+    print(f"  Files to skip     : {plan.skipped_count}  (already on device)")
+    print(f"  Dirs to create    : {len(plan.dirs_to_create)}")
+
+    if not args.execute:
+        print("\nDry run.  Pass --execute to transfer files.")
+        sys.exit(0)
+
+    def on_progress(current: int, total: int, op: FileTransferOp, status: str) -> None:
+        mark = "✓" if status == "ok" else "✗"
+        print(f"  [{current:>4}/{total}] {mark} {op.filename}")
+
+    print("\nStarting transfer...")
+    result = syncer.execute_plan(plan, progress_callback=on_progress)
+
+    print(f"\n=== Result ===")
+    print(f"  Uploaded : {result.uploaded}")
+    print(f"  Skipped  : {result.skipped}")
+    print(f"  Failed   : {result.failed}")
+    if result.errors:
+        print("  Errors:")
+        for err in result.errors:
+            print(f"    - {err}")
+    sys.exit(0 if result.failed == 0 else 1)

--- a/src/twitch_spy/android_sync/adb_sync.py
+++ b/src/twitch_spy/android_sync/adb_sync.py
@@ -263,6 +263,9 @@ class AndroidLibrarySync:
         existing_remote = self.list_remote_files(self.android_dest)
         logger.info("device has %d existing files under %s", len(existing_remote), self.android_dest)
 
+        # Derive which directories already exist on the device from the file list.
+        existing_remote_dirs: set[str] = {p.rsplit("/", 1)[0] for p in existing_remote}
+
         dirs_to_create: list[str] = []
         files_to_transfer: list[FileTransferOp] = []
         skipped = 0
@@ -283,8 +286,13 @@ class AndroidLibrarySync:
                 logger.debug("skip (exists): %s", remote_path)
                 continue
 
-            # Track unique remote directories that need creating.
-            if remote_dir != self.android_dest and remote_dir not in seen_dirs:
+            # Track unique remote directories that need creating,
+            # but only if they don't already exist on the device.
+            if (
+                remote_dir != self.android_dest
+                and remote_dir not in seen_dirs
+                and remote_dir not in existing_remote_dirs
+            ):
                 dirs_to_create.append(remote_dir)
                 seen_dirs.add(remote_dir)
 

--- a/src/twitch_spy/app.py
+++ b/src/twitch_spy/app.py
@@ -15,6 +15,7 @@ from flask import request
 
 # Routes
 from twitch_spy.routes.home_routes import home_routes
+from twitch_spy.routes.sync_routes import sync_routes
 
 
 class Application:
@@ -23,6 +24,7 @@ class Application:
         self.app = Flask(__name__, template_folder="../templates")
         CORS(self.app, resources={r"/*": {"origins": "http://localhost:5173"}})
         self.app.register_blueprint(home_routes)
+        self.app.register_blueprint(sync_routes)
         socketio.init_app(self.app)
 
         self.event_dispatcher = event_dispatcher.EventDispatcher()

--- a/src/twitch_spy/cli.py
+++ b/src/twitch_spy/cli.py
@@ -3,11 +3,12 @@ from typing import List
 
 
 class SystemConfiguration:
-    def __init__(self, urls: List[str], num_worker_threads: int, file_queue_mode: bool, output_dir: str):
+    def __init__(self, urls: List[str], num_worker_threads: int, file_queue_mode: bool, output_dir: str, android_dest: str):
         self.urls: List[str] = urls
         self.num_worker_threads: int = num_worker_threads
         self.file_queue_mode: bool = file_queue_mode
         self.output_dir: str = output_dir
+        self.android_dest: str = android_dest
 
 
 def parse_args() -> SystemConfiguration:
@@ -33,5 +34,11 @@ def parse_args() -> SystemConfiguration:
         default="./data",
         help="Directory for logs and stream downloads (default: ./data)",
     )
+    parser.add_argument(
+        "--android-dest",
+        type=str,
+        default="/sdcard/SdCardBackup/Music",
+        help="Android destination root path for sync (default: /sdcard/SdCardBackup/Music)",
+    )
     args = parser.parse_args()
-    return SystemConfiguration(args.urls, args.num_worker_threads, args.file_queue_mode, args.output_dir)
+    return SystemConfiguration(args.urls, args.num_worker_threads, args.file_queue_mode, args.output_dir, args.android_dest)

--- a/src/twitch_spy/config.py
+++ b/src/twitch_spy/config.py
@@ -4,6 +4,7 @@ import os
 STREAM_DOWNLOADS: str = None
 LOG_DIR: str = None
 AUDIO_LIBRARY: str = None
+ANDROID_DEST: str = None
 
 
 def create_directory_if_not_exists(directory_path: str):
@@ -12,12 +13,13 @@ def create_directory_if_not_exists(directory_path: str):
     return directory_path
 
 
-def init(output_dir: str):
-    global STREAM_DOWNLOADS, LOG_DIR, AUDIO_LIBRARY
+def init(output_dir: str, android_dest: str = "/sdcard/SdCardBackup/Music"):
+    global STREAM_DOWNLOADS, LOG_DIR, AUDIO_LIBRARY, ANDROID_DEST
     output_dir = path.abspath(output_dir)
     STREAM_DOWNLOADS = path.join(output_dir, "stream_downloads")
     LOG_DIR = path.join(output_dir, "logs")
     AUDIO_LIBRARY = path.join(STREAM_DOWNLOADS, "audio_library")
+    ANDROID_DEST = android_dest
     create_directory_if_not_exists(STREAM_DOWNLOADS)
     create_directory_if_not_exists(LOG_DIR)
     create_directory_if_not_exists(AUDIO_LIBRARY)

--- a/src/twitch_spy/main.py
+++ b/src/twitch_spy/main.py
@@ -15,7 +15,7 @@ def main():
     args = cli.parse_args()
 
     import twitch_spy.config as config
-    config.init(args.output_dir)
+    config.init(args.output_dir, android_dest=args.android_dest)
 
     import twitch_spy.app as app
 

--- a/src/twitch_spy/media_downloader/job_manager.py
+++ b/src/twitch_spy/media_downloader/job_manager.py
@@ -80,18 +80,12 @@ class JobManager:
         return job
 
     def job_done(self, future: Future) -> None:
-        # This is called once a job is done. You can do any cleanup or post-processing here.
-        # If the job raises an exception, you can capture it here.
         exception: Union[BaseException, None] = future.exception()
+        if exception:
+            logger.error(f"Unexpected error during job processing: {exception}", exc_info=exception)
+            return
 
         job: Atom = future.result()
-
-        if exception:
-            # Handle the exception, e.g., update the job status to failed
-            job.update_status(const.PROCESS_STATUS.FAILED)
-            self.send_update(job)
-            logger.debug(f"Processing failed for job {job}")
-            return
         # If the platform handler explicitly marked the job as FAILED, respect it
         if job.status == const.PROCESS_STATUS.FAILED:
             self.send_update(job)

--- a/src/twitch_spy/media_downloader/platform_handlers.py
+++ b/src/twitch_spy/media_downloader/platform_handlers.py
@@ -131,17 +131,23 @@ class Atomizer:
 
     @staticmethod
     def atomize_urls(
-        urls: List[str], content_mode: const.CONTENT_MODE, root_download_dir: str
+        urls: List[str],
+        content_mode: const.CONTENT_MODE,
+        root_download_dir: str,
+        on_url: Optional[Callable[[int, int], None]] = None,
     ) -> List[Atom]:
         valid_urls = list(filter(Atom._is_url_valid, urls))
+        total = len(valid_urls)
         atoms = []
-        for url in valid_urls:
+        for i, url in enumerate(valid_urls, start=1):
             atom = Atom(url, content_mode, root_download_dir)
             handler: PlatformHandler = Atomizer.PLATFORM_HANDLERS.get(atom.platform)
             if handler:
                 atoms.extend(handler.atomize(atom))
             else:
                 atoms.append(atom)  # Default behavior for unsupported platforms
+            if on_url:
+                on_url(i, total)
         return atoms
 
     @staticmethod

--- a/src/twitch_spy/media_downloader/platform_handlers.py
+++ b/src/twitch_spy/media_downloader/platform_handlers.py
@@ -42,11 +42,14 @@ class YouTubeHandler(PlatformHandler):
             new_download_dir = (
                 path.join(atom.download_dir, subdir) if subdir else atom.download_dir
             )
+            # Skip the network title fetch if the URL is already downloaded.
+            # The title will not be needed since the job will be filtered out.
+            already_done = StorageManager(new_download_dir).already_downloaded(atom.url)
             new_atom = Atom(
                 atom.url,
                 atom.content_type,
                 new_download_dir,
-                content_title=youtube.get_video_title(atom.url),
+                content_title=None if already_done else youtube.get_video_title(atom.url),
             )
             return [new_atom]
         video_metadatas = youtube.get_playlist_video_urls(atom.url)

--- a/src/twitch_spy/media_downloader/platform_handlers.py
+++ b/src/twitch_spy/media_downloader/platform_handlers.py
@@ -42,20 +42,26 @@ class YouTubeHandler(PlatformHandler):
             new_download_dir = (
                 path.join(atom.download_dir, subdir) if subdir else atom.download_dir
             )
-            # Skip the network title fetch if the URL is already downloaded.
-            # The title will not be needed since the job will be filtered out.
-            already_done = StorageManager(new_download_dir).already_downloaded(atom.url)
+            # Title is resolved later during download_audio() from info_dict,
+            # avoiding a redundant network round-trip here.
             new_atom = Atom(
                 atom.url,
                 atom.content_type,
                 new_download_dir,
-                content_title=None if already_done else youtube.get_video_title(atom.url),
+                content_title=None,
             )
             return [new_atom]
-        video_metadatas = youtube.get_playlist_video_urls(atom.url)
-        playlist_directory = youtube.get_playlist_download_directory(
-            atom.download_dir, atom.url
-        )
+        try:
+            video_metadatas = youtube.get_playlist_video_urls(atom.url)
+            playlist_directory = youtube.get_playlist_download_directory(
+                atom.download_dir, atom.url
+            )
+        except Exception as exc:
+            logger.warning("Skipping unsupported URL %s: %s", atom.url, exc)
+            return []
+        if not video_metadatas:
+            logger.warning("No videos found for URL %s, skipping", atom.url)
+            return []
         return [
             Atom(
                 vid.url,

--- a/src/twitch_spy/media_downloader/storage_manager.py
+++ b/src/twitch_spy/media_downloader/storage_manager.py
@@ -44,8 +44,7 @@ class StorageManager:
 
     @staticmethod
     def ensure_folder_exists(folder_path: str) -> str:
-        if not path.exists(folder_path):
-            os.makedirs(folder_path)
+        os.makedirs(folder_path, exist_ok=True)
         return folder_path
 
     @staticmethod

--- a/src/twitch_spy/media_downloader/youtube.py
+++ b/src/twitch_spy/media_downloader/youtube.py
@@ -1,6 +1,9 @@
 import base64
+import logging
 import re
 import traceback
+
+logger = logging.getLogger(__name__)
 import os
 import os.path as path
 import re
@@ -269,6 +272,7 @@ class YoutubeDownloader:
         }
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info_dict = ydl.extract_info(atom.url, download=False)
+            atom.content_title = info_dict.get("title") or atom.content_title
             filename = ydl.prepare_filename(info_dict)
             filename = path.abspath(filename)
             # Change the extension to mp3
@@ -333,6 +337,10 @@ def get_playlist_video_urls(playlist_url: str) -> list[VideoMetadata]:
     ) as ydl:
         playlist_dict = ydl.extract_info(playlist_url, download=False)
 
+    if not playlist_dict or "entries" not in playlist_dict:
+        logger.warning("Could not extract playlist info for %s", playlist_url)
+        return []
+
     res = []
     for video in playlist_dict["entries"]:
         if video is not None:
@@ -394,9 +402,10 @@ def safe_pathname(dir: str) -> str:
     return re.sub(r'[\\/:*?"<>| ]', "_", dir)
 
 
-def extract_playlist_id(url: str) -> str:
-    """Extract the playlist ID from the URL."""
-    return re.search(r"list=([\w-]+)", url).group(1)
+def extract_playlist_id(url: str) -> Optional[str]:
+    """Extract the playlist ID from the URL, or None if not present."""
+    m = re.search(r"list=([\w-]+)", url)
+    return m.group(1) if m else None
 
 
 def get_playlist_download_directory(playlists_directory: str, playlist_url: str):
@@ -411,6 +420,8 @@ def get_playlist_download_directory(playlists_directory: str, playlist_url: str)
         return None
 
     playlist_id = extract_playlist_id(playlist_url)
+    if not playlist_id:
+        raise ValueError(f"No playlist ID found in URL: {playlist_url}")
     existing_dir = find_existing_directory(playlists_directory, playlist_id)
     if existing_dir:
         print(f"Found existing directory by project id: {playlist_id}")

--- a/src/twitch_spy/media_downloader/youtube.py
+++ b/src/twitch_spy/media_downloader/youtube.py
@@ -1,3 +1,4 @@
+import base64
 import re
 import traceback
 import os
@@ -290,7 +291,9 @@ class YoutubeDownloader:
                 thumbnail_path = YoutubeDownloader.add_preview_picture_to_audio_file(
                     info_dict.get("title", None), thumbnail_url, filename
                 )
-                atom.thumbnail_image_in_base64 = thumbnail_path  # Store thumbnail path
+                if thumbnail_path and path.exists(thumbnail_path):
+                    with open(thumbnail_path, "rb") as f:
+                        atom.thumbnail_image_in_base64 = base64.b64encode(f.read()).decode("utf-8")
             except Exception as e:
                 raise e
             return filename

--- a/src/twitch_spy/routes/home_routes.py
+++ b/src/twitch_spy/routes/home_routes.py
@@ -42,10 +42,17 @@ def form_submit():
         urls_list = [normalize_url(url.strip()) for url in re.split(r"[\n,]+", urls) if url.strip()]
         logger.debug(f"URLs list: {urls_list}")
 
+        total = len(urls_list)
+        socketio.emit("url_planning", {"current": 0, "total": total})
+
+        def _on_url(current: int, total: int) -> None:
+            socketio.emit("url_planning", {"current": current, "total": total})
+
         jobs = ph.Atomizer.atomize_urls(
             urls_list,
             const.CONTENT_MODE.AUDIO,
             config.AUDIO_LIBRARY,
+            on_url=_on_url,
         )
         existing_urls = {j.url for j in my_app.job_manager.get_all_jobs()}
         new_jobs = [

--- a/src/twitch_spy/routes/home_routes.py
+++ b/src/twitch_spy/routes/home_routes.py
@@ -1,4 +1,6 @@
 from uuid import UUID
+import re
+from urllib.parse import urlparse, urlunparse
 import psutil
 from flask import Blueprint, render_template, jsonify, send_file
 import twitch_spy.config as config
@@ -20,6 +22,13 @@ import time
 home_routes = Blueprint("home_routes", __name__)
 
 
+def normalize_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.netloc == "music.youtube.com":
+        parsed = parsed._replace(netloc="www.youtube.com")
+    return urlunparse(parsed)
+
+
 @home_routes.route("/form_submit", methods=["POST"])
 def form_submit():
     logger.debug("Handling form submit.")
@@ -30,19 +39,22 @@ def form_submit():
     urls = data.get("urls")
     logger.debug(f"URLs: {urls}")
     if urls:
-        urls_list = [url.strip() for url in urls.split("\n")]
+        urls_list = [normalize_url(url.strip()) for url in re.split(r"[\n,]+", urls) if url.strip()]
         logger.debug(f"URLs list: {urls_list}")
-        user_input = sm.StorageManager(config.STREAM_DOWNLOADS)
-        for url in urls_list:
-            user_input.mark_successful_download(url)
+
         jobs = ph.Atomizer.atomize_urls(
             urls_list,
             const.CONTENT_MODE.AUDIO,
             config.AUDIO_LIBRARY,
         )
-        logger.debug(f"Jobs created: {jobs}")
-        logger.debug(f"Number of jobs: {len(jobs)}")
-        for job in jobs:
+        existing_urls = {j.url for j in my_app.job_manager.get_all_jobs()}
+        new_jobs = [
+            job for job in jobs
+            if job.url not in existing_urls
+            and not sm.StorageManager(job.download_dir).already_downloaded(job.url)
+        ]
+        logger.debug(f"Jobs after dedup: {len(new_jobs)} (skipped {len(jobs) - len(new_jobs)})")
+        for job in new_jobs:
             my_app.job_manager.add_job(job)
             my_app.event_dispatcher.dispatch_event(Events.JOB_CREATED.value, job)
             my_app.event_dispatcher.dispatch_event(

--- a/src/twitch_spy/routes/sync_routes.py
+++ b/src/twitch_spy/routes/sync_routes.py
@@ -1,0 +1,122 @@
+"""
+Flask routes for Android sync.
+
+Endpoints
+---------
+GET  /sync/devices   — check whether a device is connected via adb
+POST /sync/plan      — compute transfer operations without touching the device
+POST /sync/execute   — run a plan in a background thread; emits Socket.IO events
+                       for progress and completion
+
+Socket.IO events emitted during execute
+----------------------------------------
+  sync_progress  { current, total, filename, remote_path, status }
+  sync_complete  { uploaded, skipped, failed, errors }
+"""
+
+import threading
+
+import flask
+from flask import Blueprint, jsonify, request
+
+import twitch_spy.config as config
+import twitch_spy.util as util
+from twitch_spy.android_sync.adb_sync import (
+    AndroidLibrarySync,
+    FileTransferOp,
+    SyncPlan,
+)
+from twitch_spy.socket_instance import socketio
+from twitch_spy.system_logger import logger
+
+sync_routes = Blueprint("sync_routes", __name__)
+
+
+def _syncer() -> AndroidLibrarySync:
+    return AndroidLibrarySync(
+        adb_exe="adb.exe",
+        android_dest=config.ANDROID_DEST,
+    )
+
+
+@sync_routes.route("/sync/devices", methods=["GET"])
+def get_devices():
+    """List connected adb devices and report whether any are online."""
+    syncer = _syncer()
+    devices = syncer.list_devices()
+    return jsonify({"devices": devices, "connected": len(devices) > 0})
+
+
+@sync_routes.route("/sync/plan", methods=["POST"])
+def plan_sync():
+    """
+    Compute the set of files that need to be transferred.
+
+    Reads the remote device once (bulk find) and walks the local audio library.
+    Returns a SyncPlan JSON object that the client holds and sends back on confirm.
+
+    No files are written to the device.
+    """
+    syncer = _syncer()
+
+    if not syncer.device_connected():
+        return jsonify({"error": "No Android device connected via adb"}), 503
+
+    try:
+        plan = syncer.plan_sync(config.AUDIO_LIBRARY)
+        return jsonify(plan.to_dict())
+    except Exception as exc:
+        logger.error("plan_sync error: %s", exc)
+        return jsonify({"error": str(exc)}), 500
+
+
+@sync_routes.route("/sync/execute", methods=["POST"])
+def execute_sync():
+    """
+    Accept a SyncPlan (JSON body from /sync/plan) and execute it.
+
+    Returns 202 immediately.  Progress is streamed via Socket.IO:
+      - sync_progress  { current, total, filename, remote_path, status }
+      - sync_complete  { uploaded, skipped, failed, errors }
+
+    The plan is re-validated on the server so the client cannot inject
+    arbitrary paths.
+    """
+    data = request.json or {}
+
+    try:
+        plan = SyncPlan(
+            dirs_to_create=list(data["dirs_to_create"]),
+            files_to_transfer=[
+                FileTransferOp(**op) for op in data["files_to_transfer"]
+            ],
+            skipped_count=int(data["skipped_count"]),
+            total_transfer_bytes=int(data["total_transfer_bytes"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        return jsonify({"error": f"Invalid plan payload: {exc}"}), 400
+
+    syncer = _syncer()
+
+    def run() -> None:
+        def on_progress(
+            current: int, total: int, op: FileTransferOp, status: str
+        ) -> None:
+            socketio.emit(
+                "sync_progress",
+                {
+                    "current": current,
+                    "total": total,
+                    "filename": op.filename,
+                    "remote_path": op.remote_path,
+                    "status": status,
+                },
+            )
+
+        result = syncer.execute_plan(plan, progress_callback=on_progress)
+        socketio.emit("sync_complete", result.to_dict())
+
+    thread = threading.Thread(target=run, daemon=True, name="android-sync")
+    thread.start()
+
+    return jsonify({"message": "Sync started"}), 202


### PR DESCRIPTION
Media library improvements: robustness, deduplication, Android sync, and UI overhaul

  Summary

  This branch delivers a series of improvements to the download pipeline, deduplication logic, Android sync, and the
  frontend UI. Changes were made across the full stack.

  ---
  Backend

  Download pipeline reliability
  - Fixed a TOCTOU race condition in StorageManager.ensure_folder_exists — replaced the if not exists / makedirs pattern
  with makedirs(exist_ok=True), preventing FileExistsError crashes under concurrent job processing
  - Fixed job_done in JobManager — previously called future.result() before checking future.exception(), causing re-raised
   exceptions to leave jobs stuck in PROCESSING forever; order is now correct
  - Removed per-URL network pre-fetching during atomization — video titles are now resolved lazily inside download_audio()
   from the info_dict already fetched for the download, eliminating one yt-dlp round-trip per URL
  - Fixed thumbnail storage — was incorrectly storing the local file path string instead of base64-encoded image data;
  frontend now receives a renderable image immediately after download completes

  URL handling and deduplication
  - URL splitting now handles both newline and comma separators (re.split(r"[\n,]+", ...))
  - Added normalize_url() to rewrite music.youtube.com → www.youtube.com before any processing, preventing duplicate
  downloads from the same video via different subdomains
  - Added two-level deduplication on form submit: jobs already in the queue and jobs already in local_storage.txt are both
   filtered out before being added to the job manager

  Error resilience for large batches
  - YouTubeHandler.atomize() now wraps the playlist extraction path in a try/except, so unsupported or malformed URLs
  (e.g. /podcast/...) are skipped with a warning instead of crashing the entire batch
  - get_playlist_video_urls() guards against None or missing entries from yt-dlp
  - extract_playlist_id() returns Optional[str] instead of crashing on URLs with no list= parameter;
  get_playlist_download_directory() raises a clean ValueError in that case

  Android sync (adb_sync.py)
  - plan_sync() now derives the set of existing remote directories from the bulk adb shell find result, so directories
  already present on the device are excluded from dirs_to_create

  Planning progress via Socket.IO
  - atomize_urls accepts an optional on_url callback; form_submit uses it to emit url_planning events so the frontend can
  show progress during the atomization phase

  ---
  Frontend

  URL input
  - Listens for url_planning Socket.IO events and shows a "Planning X / N…" counter while the backend is atomizing URLs
  - Sends cleanedInput (stripped/normalized) to the backend instead of raw userInput, fixing JSON array inputs that
  previously bypassed cleaning

  Audio player
  - Restructured the now-playing dock into three columns: track info (left), custom play/pause button (center), progress
  bar + volume (right)
  - The play/pause button is a custom 80px-wide element styled to match the dark theme; RHAP's built-in controls are
  replaced via customControlsSection and customProgressBarSection
  - Playback state is controlled via a ref to the underlying <audio> element; onPlay/onPause events keep the button in
  sync
  - Added comprehensive global RHAP CSS overrides to theme the player (transparent background, accent-colored progress
  bar/indicator, muted time labels, styled volume)

  Android sync panel (SyncPanel.tsx)
  - New full-featured sync panel for planning and executing one-way library sync to an Android device via adb